### PR TITLE
Fix i18n file include in scaffold

### DIFF
--- a/pyramid_closure/scaffold/+package+/templates/index.html_tmpl
+++ b/pyramid_closure/scaffold/+package+/templates/index.html_tmpl
@@ -34,7 +34,7 @@
     <script>
       (function() {
          var module = angular.module('app');
-         module.constant('langUrlTemplate', '${request.static_url('{{package}}:static/build/locale/__lang__/projectsample.json')}');
+         module.constant('langUrlTemplate', '${request.static_url('{{package}}:static/build/locale/__lang__/{{package}}.json')}');
        })();
     </script>
   </body>


### PR DESCRIPTION
Use `locale/__lang__/{{package}}.json` instead of `locale/__lang__/projectsample.json` so that the real project name is used.