### PR TITLE
Add ngeo closure externs to build.json

### DIFF
--- a/pyramid_closure/scaffold/build.json_tmpl
+++ b/pyramid_closure/scaffold/build.json_tmpl
@@ -17,6 +17,10 @@
       "node_modules/openlayers/externs/topojson.js",
       "node_modules/openlayers/externs/vbarray.js",
       "node_modules/ngeo/externs/angular-gettext.js",
+      "node_modules/ngeo/externs/angular-local-storage.js",
+      "node_modules/ngeo/externs/closure-compiler.js",
+      "node_modules/ngeo/externs/twbootstrap.js",
+      "node_modules/ngeo/externs/typeahead.js",
       ".build/externs/angular-1.3.js",
       ".build/externs/angular-1.3-q.js",
       ".build/externs/angular-1.3-http-promise.js"


### PR DESCRIPTION
Otherwise the compilation will fail when using `ngeo.GetBrowserLanguage` with the following error message:

    ERR! compile app/node_modules/ngeo/src/services/getbrowserlanguage.js:31: ERROR - Property languages never defined on Navigator
    ERR! compile         var browserLanguages = nav.languages || nav.language ||
    ERR! compile                                    ^
    ERR! compile 
    ERR! compile app/node_modules/ngeo/src/services/getbrowserlanguage.js:32: ERROR - Property systemLanguage never defined on Navigator
    ERR! compile             nav.browserLanguage || nav.systemLanguage || nav.userLanguage;
    ERR! compile                                        ^
    ERR! compile 
    ERR! compile 
    ERR! compile app/node_modules/ngeo/src/services/getbrowserlanguage.js:32: ERROR - Property userLanguage never defined on Navigator
    ERR! compile             nav.browserLanguage || nav.systemLanguage || nav.userLanguage;
