### PR TITLE
Use static_url in deps view

### DIFF
--- a/ProjectSample/Makefile
+++ b/ProjectSample/Makefile
@@ -137,4 +137,4 @@ $(SITE_PACKAGES)/ProjectSample.egg-link: .build/venv setup.py
 	.build/venv/bin/pip install -r requirements.txt
 
 common.ini: common.ini.in
-	sed 's|__CLOSURE_LIBRARY_PATH__|$(CLOSURE_LIBRARY_PATH)|' $< > $@
+	sed 's|__CLOSURE_LIBRARY_PATH__|$(CLOSURE_LIBRARY_PATH)|g' $< > $@

--- a/ProjectSample/common.ini.in
+++ b/ProjectSample/common.ini.in
@@ -8,12 +8,11 @@ use = egg:ProjectSample
 pyramid.default_locale_name = en
 
 # pyramid_closure configuration
-pyramid_closure.roots =
-    __CLOSURE_LIBRARY_PATH__/closure/goog
 pyramid_closure.roots_with_prefix =
-    ../../../../../../../../../static/js %(here)s/projectsample/static/js
-    ../../../../../../../../../node_modules/openlayers %(here)s/node_modules/openlayers
-    ../../../../../../../../../node_modules/ngeo %(here)s/node_modules/ngeo
+    __CLOSURE_LIBRARY_PATH__/closure/goog __CLOSURE_LIBRARY_PATH__/closure/goog
+    projectsample:static/js %(here)s/projectsample/static/js
+    %(here)s/node_modules/openlayers %(here)s/node_modules/openlayers
+    %(here)s/node_modules/ngeo %(here)s/node_modules/ngeo
 
 # used for the "node_modules" and "closure" static views
 node_modules_path = %(here)s/node_modules/

--- a/ProjectSample/projectsample/templates/index.html
+++ b/ProjectSample/projectsample/templates/index.html
@@ -23,6 +23,13 @@
     <h1 translate>Hello!</h1>
     <div id="map" ngeo-map="mainCtrl.map"></div>
 % if debug:
+    <script>
+      // We should really use the empty string for CLOSURE_BASE_PATH for there
+      // is a bug in Closure Library preventing us from doing it. See
+      // <https://github.com/google/closure-library/pull/418>.
+      window.CLOSURE_BASE_PATH = ' ';
+      window.CLOSURE_NO_DEPS = true;
+    </script>
     <script src="${request.static_url('%s/angular-gettext/dist/angular-gettext.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/closure/goog/base.js' % closure_library_path)}"></script>
     <script src="${request.route_url('deps.js')}"></script>

--- a/pyramid_closure/scaffold/+package+/templates/index.html_tmpl
+++ b/pyramid_closure/scaffold/+package+/templates/index.html_tmpl
@@ -23,6 +23,13 @@
     <h1 translate>Hello!</h1>
     <div id="map" ngeo-map="mainCtrl.map"></div>
 % if debug:
+    <script>
+      // We should really use the empty string for CLOSURE_BASE_PATH for there
+      // is a bug in Closure Library preventing us from doing it. See
+      // <https://github.com/google/closure-library/pull/418>.
+      window.CLOSURE_BASE_PATH = ' ';
+      window.CLOSURE_NO_DEPS = true;
+    </script>
     <script src="${request.static_url('%s/angular-gettext/dist/angular-gettext.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/closure/goog/base.js' % closure_library_path)}"></script>
     <script src="${request.route_url('deps.js')}"></script>

--- a/pyramid_closure/scaffold/Makefile_tmpl
+++ b/pyramid_closure/scaffold/Makefile_tmpl
@@ -137,4 +137,4 @@ $(SITE_PACKAGES)/{{project}}.egg-link: .build/venv setup.py
 	.build/venv/bin/pip install -r requirements.txt
 
 common.ini: common.ini.in
-	sed 's|__CLOSURE_LIBRARY_PATH__|$(CLOSURE_LIBRARY_PATH)|' $< > $@
+	sed 's|__CLOSURE_LIBRARY_PATH__|$(CLOSURE_LIBRARY_PATH)|g' $< > $@

--- a/pyramid_closure/scaffold/common.ini.in_tmpl
+++ b/pyramid_closure/scaffold/common.ini.in_tmpl
@@ -8,12 +8,11 @@ use = egg:{{project}}
 pyramid.default_locale_name = en
 
 # pyramid_closure configuration
-pyramid_closure.roots =
-    __CLOSURE_LIBRARY_PATH__/closure/goog
 pyramid_closure.roots_with_prefix =
-    ../../../../../../../../../static/js %(here)s/{{package}}/static/js
-    ../../../../../../../../../node_modules/openlayers %(here)s/node_modules/openlayers
-    ../../../../../../../../../node_modules/ngeo %(here)s/node_modules/ngeo
+    __CLOSURE_LIBRARY_PATH__/closure/goog __CLOSURE_LIBRARY_PATH__/closure/goog
+    {{package}}:static/js %(here)s/{{package}}/static/js
+    %(here)s/node_modules/openlayers %(here)s/node_modules/openlayers
+    %(here)s/node_modules/ngeo %(here)s/node_modules/ngeo
 
 # used for the "node_modules" and "closure" static views
 node_modules_path = %(here)s/node_modules/

--- a/pyramid_closure/views.py
+++ b/pyramid_closure/views.py
@@ -1,14 +1,17 @@
-from itertools import izip
+from itertools import izip, chain
 
 from pyramid.settings import aslist
 
 from .closure import depswriter
 
 
+def flatten(l):
+    "Flatten one level of nesting"
+    return chain.from_iterable(l)
+
+
 def pairwise(iterable):
-    if isinstance(iterable, dict):
-        return iterable.iteritems()
-    a = iter(aslist(iterable))
+    a = flatten(iterable)
     return izip(a, a)
 
 
@@ -20,17 +23,28 @@ def depsjs(request):
 
     roots = pyramid_closure.get("roots") if pyramid_closure else \
         settings.get("pyramid_closure.roots")
-    roots = aslist(roots or [])
+
+    if roots is None:
+        roots = []
+    elif isinstance(roots, basestring):
+        roots = aslist(roots)
+
     for root in roots:
         path_to_source.update(depswriter._GetRelativePathToSourceDict(root))
 
     roots_with_prefix = pyramid_closure.get("roots_with_prefix") if \
         pyramid_closure else \
         settings.get("pyramid_closure.roots_with_prefix")
-    roots_with_prefix = pairwise(roots_with_prefix or {})
-    for prefix, root in roots_with_prefix:
+
+    if roots_with_prefix is None:
+        roots_with_prefix = []
+    elif isinstance(roots_with_prefix, basestring):
+        roots_with_prefix = aslist(roots_with_prefix)
+
+    for prefix, root in pairwise(roots_with_prefix):
         path_to_source.update(
-            depswriter._GetRelativePathToSourceDict(root, prefix=prefix))
+            depswriter._GetRelativePathToSourceDict(
+                root, prefix=request.static_url(prefix)))
 
     request.response.content_type = 'text/javascript'
 


### PR DESCRIPTION
This PR changes the closure-deps view to use `static_url` when generating to use URLs for scripts loaded by Closure Library. This makes the view compatible with Pyramid's cache busting mechanism.